### PR TITLE
Adding jyro to binder requirements

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -19,3 +19,4 @@ sphinxcontrib-napoleon
 recommonmark
 metakernel
 pydot
+jyro


### PR DESCRIPTION
jyro is required for the notebook demos